### PR TITLE
Roadmap + bessely/besselh wrappers + besselj_up_recurrence fix

### DIFF
--- a/src/bessels.f90
+++ b/src/bessels.f90
@@ -17,6 +17,7 @@
 module bessels
     use bessels_constants
     use bessels_debye
+    use bessels_gamma, only: gamma_BK
 
     implicit none
     private
@@ -26,9 +27,11 @@ module bessels
 
     public :: besseli0,besseli1
     public :: besselj0,besselj1,besseljn
-    public :: bessely0,bessely1
+    public :: bessely0,bessely1,bessely
     public :: besselk0,besselk1
+    public :: besselh,hankelh1,hankelh2
 
+    public :: gamma_BK
 
     public :: cbrt
     public :: ZERO,ONE,THIRD
@@ -214,9 +217,94 @@ module bessels
         endif
     end function besseljn
 
+    ! Bessel function of the second kind of variable real order nu, ``Y_{nu}(x)``.
+    !
+    ! Branch 1: x <  0      -> NaN (Y_nu is real-valued for x > 0)
+    ! Branch 2: x == 0      -> -infinity (matches bessely0/bessely1 at 0)
+    ! Branch 3: nu >= 0     -> delegate to bessely_positive_args
+    ! Branch 4: nu <  0     -> reflection Y_{-nu}(x) = cos(pi*nu)*Y_nu(x) + sin(pi*nu)*J_nu(x)
+    elemental real(BK) function bessely(nu, x)
+       real(BK), intent(in) :: nu, x
+       real(BK) :: anu, Yp, Jp
+
+       if (x < ZERO) then
+          bessely = ieee_value(bessely, ieee_quiet_nan)
+       elseif (x == ZERO) then
+          bessely = ieee_value(bessely, ieee_negative_inf)
+       elseif (nu >= ZERO) then
+          bessely = bessely_positive_args(nu, x)
+       else
+          anu = -nu
+          Yp  = bessely_positive_args(anu, x)
+          Jp  = besselj_positive_args(anu, x)
+          bessely = cos(PI*anu)*Yp + sin(PI*anu)*Jp
+       endif
+
+    end function bessely
+
+    ! Hankel function H^{(k)}_{nu}(x) = J_{nu}(x) + (-1)^{k+1} i*Y_{nu}(x) for k in {1, 2}.
+    ! Real x > 0 only. Returns NaN+NaN*i for x <= 0.
+    !
+    ! Implementation note: we always compose H = J + i*Y from the scalar
+    ! besselj_positive_args / bessely_positive_args. The hankel_debye helper
+    ! in bessels_debye is faster for x > ~nu but currently produces wrong
+    ! complex values (port bug, see todo/07-nonintegerNU-bugs.md). The
+    ! compose path is correct for integer nu; non-integer nu inherits the
+    ! latent bugs in bessely_positive_args.
+    !
+    ! Negative-nu reflection: H^{(1)}_{-nu}(x) = exp(+i*pi*nu) * H^{(1)}_{nu}(x),
+    !                        H^{(2)}_{-nu}(x) = exp(-i*pi*nu) * H^{(2)}_{nu}(x).
+    elemental complex(BK) function besselh(nu, k, x)
+       real(BK), intent(in) :: nu, x
+       integer,  intent(in) :: k
+
+       real(BK)    :: J, Y, anu
+       complex(BK) :: H
+
+       if (x <= ZERO) then
+          besselh = cmplx(ieee_value(ZERO, ieee_quiet_nan), &
+                          ieee_value(ZERO, ieee_quiet_nan), BK)
+          return
+       endif
+
+       anu = abs(nu)
+
+       J = besselj_positive_args(anu, x)
+       Y = bessely_positive_args(anu, x)
+       H = cmplx(J, Y, BK)
+
+       ! Apply negative-nu reflection before optionally conjugating for k=2
+       if (nu < ZERO) then
+          if (k == 1) then
+             H = H * exp(cmplx(ZERO,  PI*anu, BK))
+          else
+             H = H * exp(cmplx(ZERO, -PI*anu, BK))
+          endif
+       endif
+
+       if (k == 1) then
+          besselh = H
+       else
+          besselh = conjg(H)
+       endif
+
+    end function besselh
+
+    ! Hankel function of the first kind, H^{(1)}_{nu}(x) = J_{nu}(x) + i*Y_{nu}(x).
+    elemental complex(BK) function hankelh1(nu, x)
+       real(BK), intent(in) :: nu, x
+       hankelh1 = besselh(nu, 1, x)
+    end function hankelh1
+
+    ! Hankel function of the second kind, H^{(2)}_{nu}(x) = J_{nu}(x) - i*Y_{nu}(x).
+    elemental complex(BK) function hankelh2(nu, x)
+       real(BK), intent(in) :: nu, x
+       hankelh2 = besselh(nu, 2, x)
+    end function hankelh2
+
     ! Recurrence J_{nu}(x)
 
-    ! At this point we must fill the region when x Å v with recurrence
+    ! At this point we must fill the region when x ï¿½ v with recurrence
     ! Backward recurrence is always stable and forward recurrence is stable when x > nu
     ! However, we only use backward recurrence by shifting the order up and using `besseljy_debye` to
     ! generate start values. Both `besseljy_debye` and `hankel_debye` get more accurate for large orders,

--- a/src/bessels_constants.f90
+++ b/src/bessels_constants.f90
@@ -748,7 +748,7 @@ module bessels_constants
     ! Power series for Y_{nu}(x)
 
     ! Use power series form of J_v(x) to calculate Y_v(x) with
-    ! Y_v(x) = (J_v(x)cos(v*¹) - J_{-v}(x)) / sin(v*pi),    v ~= 0, 1, 2, ...
+    ! Y_v(x) = (J_v(x)cos(v*ï¿½) - J_{-v}(x)) / sin(v*pi),    v ~= 0, 1, 2, ...
     ! combined to calculate both J_v and J_{-v} in the same loop (J_{-v} always converges slower)
 
     ! this works well for small arguments x < 7.0 for rel. error ~1e-14
@@ -852,8 +852,8 @@ module bessels_constants
 
         ! avoid inexact floating points when nu is a float
         do while (nu<nu_end+HALF)
-            jnu2 = [jnu2(2),nu_start*x2*jnu2(2)-jnu2(1)]
-            nu = nu-ONE
+            jnu2 = [jnu2(2),nu*x2*jnu2(2)-jnu2(1)]
+            nu = nu+ONE
         end do
 
         a = jnu2(1)

--- a/test/bessels_test.f90
+++ b/test/bessels_test.f90
@@ -26,6 +26,7 @@ program bessels_test
     call add_test(test_bessel_jn())
     call add_test(test_bessel_y0())
     call add_test(test_bessel_y1())
+    call add_test(test_besselj_up_recurrence())
     call add_test(test_bessel_k0())
     call add_test(test_bessel_k1())
     call add_test(test_bessel_i0())
@@ -858,6 +859,38 @@ program bessels_test
        real(BK), intent(in) :: x,RTOL,ATOL
        rewt = ONE/(RTOL*abs(x)+ATOL)
     end function rewt
+
+    ! Regression test for besselj_up_recurrence bug fix.
+    ! Forward Y-recurrence from Y_0, Y_1 must reach the correct Y_n for integer n,
+    ! with coefficient (2k/x) updated each step. Before the fix the coefficient was
+    ! frozen at nu_start*2/x and the loop counter ran backwards.
+    logical function test_besselj_up_recurrence() result(success)
+       use bessels_constants, only: besselj_up_recurrence
+
+       real(BK), parameter :: RTOL = 1e-10_BK
+       real(BK), parameter :: ATOL = 1e-14_BK
+       real(BK), parameter :: x_test(3) = [0.5_BK, 2.0_BK, 10.0_BK]
+       real(BK) :: x, Y_pkg, Y_next, Y_intr, err
+       integer  :: n, i
+
+       success = .true.
+
+       do i = 1, size(x_test)
+          x = x_test(i)
+          do n = 1, 10
+             call besselj_up_recurrence(x, bessely1(x), bessely0(x), &
+                                        ONE, real(n,BK), Y_pkg, Y_next)
+             Y_intr = bessel_yn(n, x)
+             err = abs(Y_pkg - Y_intr) * rewt(Y_intr, RTOL, ATOL)
+             if (err >= ONE) then
+                success = .false.
+                print *, '[besselj_up_recurrence] x=', x, ' n=', n, &
+                         ' package=', Y_pkg, ' intrinsic=', Y_intr, ' relerr=', err
+             end if
+          end do
+       end do
+
+    end function test_besselj_up_recurrence
 
     ! Test approximated cube root
     logical function test_cuberoot() result(success)

--- a/test/bessels_test.f90
+++ b/test/bessels_test.f90
@@ -27,6 +27,9 @@ program bessels_test
     call add_test(test_bessel_y0())
     call add_test(test_bessel_y1())
     call add_test(test_besselj_up_recurrence())
+    call add_test(test_bessely_nu_integer())
+    call add_test(test_hankelh1_consistency())
+    call add_test(test_hankelh2_conjugate())
     call add_test(test_bessel_k0())
     call add_test(test_bessel_k1())
     call add_test(test_bessel_i0())
@@ -37,6 +40,8 @@ program bessels_test
     call add_test(test_bessel_jn_cputime())
     call add_test(test_bessel_y0_cputime())
     call add_test(test_bessel_y1_cputime())
+    call add_test(test_bessely_nu_cputime())
+    call add_test(test_hankelh1_cputime())
     call add_test(test_bessel_k0_cputime())
     call add_test(test_bessel_k1_cputime())
     call add_test(test_bessel_i0_cputime())
@@ -731,7 +736,6 @@ program bessels_test
 
     ! Test bessel k0 function
     logical function test_gamma() result(success)
-      use bessels_gamma
 
       integer, parameter :: NTEST = 2000
 
@@ -766,7 +770,6 @@ program bessels_test
 
     ! Test bessel j0 cpu time
     logical function test_gamma_cputime() result(success)
-        use bessels_gamma
 
         integer, parameter :: nsize = 100000
         integer, parameter :: ntest = 100
@@ -891,6 +894,191 @@ program bessels_test
        end do
 
     end function test_besselj_up_recurrence
+
+    ! Test bessely(real nu, x) against bessel_yn intrinsic for integer nu.
+    logical function test_bessely_nu_integer() result(success)
+
+       integer, parameter :: NTEST = 1000
+       real(BK), parameter :: xmin = 0.1_BK
+       real(BK), parameter :: xmax = 1e+2_BK
+       real(BK), parameter :: RTOL = 1e-6_BK
+       real(BK), parameter :: ATOL = 1e-10_BK
+       real(BK) :: x(NTEST), fun(NTEST), intr(NTEST), err(NTEST)
+       integer  :: i, n
+
+       call random_number(x)
+       x = xmin*(ONE-x) + xmax*x
+
+       success = .true.
+
+       do n = 0, 10
+          do i = 1, NTEST
+             fun(i) = bessely(real(n,BK), x(i))
+          end do
+          intr = bessel_yn(n, x)
+          err  = abs(fun-intr) * rewt(intr, RTOL, ATOL)
+
+          success = success .and. all(err<one)
+
+          if (.not. all(err<one)) then
+             do i = 1, NTEST
+                if (err(i) >= one) &
+                   print *, '[bessely_nu_int] n=',n,' x=',x(i),' package=',fun(i),' intrinsic=',intr(i),' relerr=',err(i)
+             end do
+          end if
+       end do
+
+    end function test_bessely_nu_integer
+
+    ! Test hankelh1(integer n, x) = J_n(x) + i*Y_n(x).
+    ! Restricted to integer nu — non-integer nu paths in bessely_positive_args
+    ! / hankel_debye have pre-existing port bugs (see todo/07-nonintegerNU-bugs.md).
+    logical function test_hankelh1_consistency() result(success)
+
+       real(BK), parameter :: RTOL = 1e-10_BK
+       real(BK), parameter :: ATOL = 1e-14_BK
+       real(BK), parameter :: x_test(4) = [0.5_BK, 5.0_BK, 30.0_BK, 100.0_BK]
+       real(BK) :: x, Jref, Yref, err_r, err_i
+       complex(BK) :: H
+       integer :: i
+
+       success = .true.
+
+       do i = 1, size(x_test)
+          x = x_test(i)
+
+          ! nu = 0
+          H    = hankelh1(0.0_BK, x)
+          Jref = besselj0(x)
+          Yref = bessely0(x)
+          err_r = abs(H%re - Jref) * rewt(Jref, RTOL, ATOL)
+          err_i = abs(H%im - Yref) * rewt(Yref, RTOL, ATOL)
+          if (err_r >= ONE .or. err_i >= ONE) then
+             success = .false.
+             print *, '[hankelh1_cons] nu=0 x=', x, ' H=', H, ' J=', Jref, ' Y=', Yref, &
+                      ' err_r=', err_r, ' err_i=', err_i
+          end if
+
+          ! nu = 1
+          H    = hankelh1(1.0_BK, x)
+          Jref = besselj1(x)
+          Yref = bessely1(x)
+          err_r = abs(H%re - Jref) * rewt(Jref, RTOL, ATOL)
+          err_i = abs(H%im - Yref) * rewt(Yref, RTOL, ATOL)
+          if (err_r >= ONE .or. err_i >= ONE) then
+             success = .false.
+             print *, '[hankelh1_cons] nu=1 x=', x, ' H=', H, ' J=', Jref, ' Y=', Yref, &
+                      ' err_r=', err_r, ' err_i=', err_i
+          end if
+       end do
+
+    end function test_hankelh1_consistency
+
+    ! Test hankelh2(n, x) = conjg(hankelh1(n, x)) for real x > 0, integer nu.
+    logical function test_hankelh2_conjugate() result(success)
+
+       real(BK), parameter :: TOL = 1e-14_BK
+       real(BK), parameter :: x_test(4) = [0.5_BK, 5.0_BK, 30.0_BK, 100.0_BK]
+       real(BK), parameter :: nu_test(3) = [0.0_BK, 1.0_BK, 3.0_BK]
+       complex(BK) :: H1, H2
+       real(BK) :: diff
+       integer :: i, j
+
+       success = .true.
+
+       do i = 1, size(x_test)
+          do j = 1, size(nu_test)
+             H1 = hankelh1(nu_test(j), x_test(i))
+             H2 = hankelh2(nu_test(j), x_test(i))
+             diff = abs(H2 - conjg(H1))
+             if (diff > TOL) then
+                success = .false.
+                print *, '[hankelh2_conj] nu=', nu_test(j), ' x=', x_test(i), &
+                         ' H1=', H1, ' H2=', H2, ' |H2-conjg(H1)|=', diff
+             end if
+          end do
+       end do
+
+    end function test_hankelh2_conjugate
+
+    ! Benchmark bessely(real nu, x) vs. bessel_yn intrinsic at nu=1.
+    logical function test_bessely_nu_cputime() result(success)
+
+       integer, parameter :: nsize = 100000
+       integer, parameter :: ntest = 100
+       real(BK), parameter :: xmin = 0.1_BK
+       real(BK), parameter :: xmax = 1e+3_BK
+       real(BK), allocatable :: x(:), intrin(:), packge(:), z(:)
+       integer :: i
+       real(BK) :: time, timep, c_start, c_end
+       allocate(x(nsize), intrin(nsize), packge(nsize), z(ntest))
+
+       call random_number(x)
+       x = xmin*(ONE-x) + xmax*x
+
+       time = ZERO
+       do i = 1, ntest
+          call cpu_time(c_start)
+          intrin = bessel_yn(1, x)
+          call cpu_time(c_end)
+          z(i) = sum(intrin)
+          time = time + c_end - c_start
+       end do
+       print "('[bessely_nu] INTRINSIC time used: ',f9.4,' ns/eval, sum(z)=',g0)", 1e9*time/(nsize*ntest), sum(z)
+
+       timep = ZERO
+       do i = 1, ntest
+          call cpu_time(c_start)
+          packge = bessely(1.0_BK, x)
+          call cpu_time(c_end)
+          z(i) = sum(packge)
+          timep = timep + c_end - c_start
+       end do
+       print "('[bessely_nu] PACKAGE   time used: ',f9.4,' ns/eval, sum(z)=',g0)", 1e9*timep/(nsize*ntest), sum(z)
+
+       success = timep < 3*time
+
+    end function test_bessely_nu_cputime
+
+    ! Benchmark hankelh1(0, x) vs. assembling cmplx(besselj0, bessely0) by hand.
+    logical function test_hankelh1_cputime() result(success)
+
+       integer, parameter :: nsize = 100000
+       integer, parameter :: ntest = 100
+       real(BK), parameter :: xmin = 0.1_BK
+       real(BK), parameter :: xmax = 1e+3_BK
+       real(BK), allocatable :: x(:), z(:)
+       complex(BK), allocatable :: baseline(:), packge(:)
+       integer :: i
+       real(BK) :: time, timep, c_start, c_end
+       allocate(x(nsize), baseline(nsize), packge(nsize), z(ntest))
+
+       call random_number(x)
+       x = xmin*(ONE-x) + xmax*x
+
+       time = ZERO
+       do i = 1, ntest
+          call cpu_time(c_start)
+          baseline = cmplx(besselj0(x), bessely0(x), BK)
+          call cpu_time(c_end)
+          z(i) = sum(baseline%re)
+          time = time + c_end - c_start
+       end do
+       print "('[hankelh1]  BASELINE  time used: ',f9.4,' ns/eval, sum(z)=',g0)", 1e9*time/(nsize*ntest), sum(z)
+
+       timep = ZERO
+       do i = 1, ntest
+          call cpu_time(c_start)
+          packge = hankelh1(0.0_BK, x)
+          call cpu_time(c_end)
+          z(i) = sum(packge%re)
+          timep = timep + c_end - c_start
+       end do
+       print "('[hankelh1]  PACKAGE   time used: ',f9.4,' ns/eval, sum(z)=',g0)", 1e9*timep/(nsize*ntest), sum(z)
+
+       success = timep < 3*time
+
+    end function test_hankelh1_cputime
 
     ! Test approximated cube root
     logical function test_cuberoot() result(success)

--- a/todo/01-wire-existing-variable-order.md
+++ b/todo/01-wire-existing-variable-order.md
@@ -1,0 +1,107 @@
+# 01 — Wire up existing variable-order machinery
+
+## Goal
+
+Ship `bessely(nu, x)`, `besselh(nu, k, x)`, `hankelh1(nu, x)`, `hankelh2(nu, x)`, and re-export `gamma_BK` from the `bessels` module. **No new numerical code** — only sign/parity wrappers around helpers that already exist.
+
+## What's already there
+
+Internal, private helpers in [src/bessels.f90](../src/bessels.f90):
+
+| Helper | Line | What it does |
+|---|---|---|
+| `besselj_positive_args(nu, x)` | [252](../src/bessels.f90#L252) | Variable-order J for `nu ≥ 0`, `x ≥ 0`. All five branches: Debye, large-arg, Hankel-Debye, series, recurrence. |
+| `bessely_positive_args(nu, x)` | [392](../src/bessels.f90#L392) | Variable-order Y for `nu ≥ 0`, `x > 0`. Integer-`nu` fast path + Debye + large-arg + Hankel + series + Chebyshev fallback. |
+| `hankel_debye(nu, x) -> complex(BK)` | [src/bessels_debye.f90:57](../src/bessels_debye.f90#L57) | Returns `H^(1)_ν(x) = J_ν + i·Y_ν` via Debye expansion, valid for `x > ~nu`. |
+| `bessely_power_series` | [src/bessels_constants.f90:762](../src/bessels_constants.f90#L762) | Returns `[Y_ν, J_ν]` simultaneously — useful for Hankel construction in the small-x branch. |
+
+`besseljn(nu, x)` in [src/bessels.f90:183](../src/bessels.f90#L183) is the integer-order wrapper around `besselj_positive_args` and is already public — model `bessely(nu, x)` directly on its shape.
+
+## What's missing
+
+1. Public `bessely(nu, x)` wrapper (real `nu`, handles `x<0` → NaN, `x=0` → −∞, `nu<0` via reflection).
+2. Public `besselh(nu, k, x)` wrapper returning `complex(BK)`, dispatching on `k ∈ {1, 2}`.
+3. Public `hankelh1(nu, x)`, `hankelh2(nu, x)` — thin one-liners over `besselh`.
+4. `bessels` module should `use bessels_gamma, only: gamma_BK` and re-export it so users get all advertised functions through one `use bessels`.
+
+## Approach
+
+### `bessely(nu, x)` — port [Bessels.jl/src/BesselFunctions/bessely.jl](https://github.com/heltonmc/Bessels.jl/blob/master/src/BesselFunctions/bessely.jl)
+
+```fortran
+elemental real(BK) function bessely(nu, x)
+   real(BK), intent(in) :: nu, x
+   real(BK) :: anu, Y, J
+   integer  :: int_nu
+   if (x < ZERO) then
+       bessely = ieee_value(bessely, ieee_quiet_nan); return    ! Y undefined for x<0
+   elseif (x == ZERO) then
+       bessely = ieee_value(bessely, ieee_negative_inf); return
+   end if
+   anu = abs(nu)
+   if (nu >= ZERO) then
+       bessely = bessely_positive_args(nu, x)
+   else
+       ! Y_{-ν}(x) = cos(πν) Y_ν(x) + sin(πν) J_ν(x)
+       Y = bessely_positive_args(anu, x)
+       J = besselj_positive_args(anu, x)
+       bessely = cos(PI*anu)*Y + sin(PI*anu)*J
+   end if
+end function
+```
+
+For integer `nu < 0`, `sin(πν) = 0` exactly (or near-zero), so the formula collapses to `Y_{-n} = (-1)^n Y_n` — the existing `cos(πν)` factor handles parity correctly if we let the elemental call short-circuit `nu ≥ 0` first. No special-case needed unless benchmarks show cancellation issues near integer `nu`.
+
+### `besselh(nu, k, x)` — port [Bessels.jl/src/BesselFunctions/hankel.jl](https://github.com/heltonmc/Bessels.jl/blob/master/src/BesselFunctions/hankel.jl)
+
+Two implementation paths:
+
+- **`x > ~nu`** (Hankel-Debye regime): call `hankel_debye(nu, x)` directly — it already returns `J + i·Y`.
+- **Otherwise**: compute `J = besselj_positive_args(nu, x)` and `Y = bessely_positive_args(nu, x)` separately, combine. (Bessels.jl has a fused `besseljy(nu,x)` — small optimization, defer.)
+
+```fortran
+elemental complex(BK) function besselh(nu, k, x)
+   real(BK), intent(in) :: nu, x
+   integer,  intent(in) :: k
+   real(BK)    :: J, Y
+   complex(BK) :: H
+   if (hankel_debye_cutoff64(nu, x)) then
+       H = hankel_debye(nu, x)
+   else
+       J = besselj_positive_args(nu, x)
+       Y = bessely_positive_args(nu, x)
+       H = cmplx(J, Y, BK)
+   end if
+   if (k == 1) then
+       besselh = H
+   else                 ! k == 2: H^(2) = conjg(H^(1)) for real x
+       besselh = conjg(H)
+   end if
+end function
+
+elemental complex(BK) function hankelh1(nu, x); ...; hankelh1 = besselh(nu, 1, x); end
+elemental complex(BK) function hankelh2(nu, x); ...; hankelh2 = besselh(nu, 2, x); end
+```
+
+Negative-`nu` reflection for Hankels follows from `H^(k)_{-ν}(x) = exp(±iπν) H^(k)_ν(x)` — apply at the top of `besselh` before dispatching.
+
+## Step-by-step
+
+1. **Re-export `gamma_BK`.** In [src/bessels.f90](../src/bessels.f90) add `use bessels_gamma, only: gamma_BK` and `public :: gamma_BK`. Verify the existing test (`test_gamma` already calls it via `use bessels_gamma`) still passes; then update the test to `use bessels` only and confirm.
+2. **Add `bessely(nu, x)`** as shown above, exported from `bessels`. Place near `besseljn` in [src/bessels.f90](../src/bessels.f90).
+3. **Add `besselh`, `hankelh1`, `hankelh2`** after `bessely`. Export all three.
+4. **Bench-guard**: confirm `bessely(0.0_BK, x)` and `bessely(1.0_BK, x)` match `bessely0(x)` / `bessely1(x)` to machine precision (they should — `bessely_positive_args` already special-cases integer `nu < 250` via `besselj_up_recurrence` from `bessely0/bessely1`).
+
+## Tests (add to [test/bessels_test.f90](../test/bessels_test.f90))
+
+- `test_bessely_nu` — for `nu ∈ {0.0, 0.5, 1.0, 1.5, 2.0, 3.7, 10.0}`, `x ∈ {0.1, 1.0, 5.0, 20.0, 100.0}`, compare against `bessely0` / `bessely1` for the integer-0/1 cases and against intrinsic `bessel_yn(int(nu), x)` for integer `nu`. Use Bessels.jl values from a known-good reference for non-integer `nu`.
+- `test_hankelh1` — verify `hankelh1(0, x) = besselj0(x) + i*bessely0(x)` for `x ∈ {0.5, 5.0, 30.0}` covers all three Hankel branches.
+- `test_hankelh2` — verify `hankelh2(nu, x) = conjg(hankelh1(nu, x))` for several `(nu, x)`.
+- `test_bessely_nu_cputime` and `test_hankelh1_cputime` — add to the benchmark block at the bottom of the test file.
+
+## Done when
+
+- All four functions (`bessely`, `besselh`, `hankelh1`, `hankelh2`) plus `gamma_BK` are reachable via `use bessels` only.
+- Test suite passes; new tests added.
+- README "not yet implemented" list shrinks by four entries; "Currently available" list grows by four.
+- No regression in existing ns/eval timings (these are new functions, not changes to hot paths).

--- a/todo/02-airy.md
+++ b/todo/02-airy.md
@@ -1,0 +1,62 @@
+# 02 — Airy functions
+
+## Goal
+
+Public `airyai(x)`, `airyaiprime(x)`, `airybi(x)`, `airybiprime(x)` plus scaled variants `airyaix`, `airyaiprimex`, `airybix`, `airybiprimex` — all `elemental real(BK)`. Real argument only; complex Airy is out of scope.
+
+## What's already there
+
+Nothing. Airy lives in its own world: Bessels.jl deliberately **avoids** routing Airy through `K_{1/3}` / `J_{1/3}` (the textbook approach) for speed and accuracy reasons. So none of the existing Bessel infrastructure is reused.
+
+Reusable from existing code:
+- `evalpoly`, `evalpoly4/5/7/8`, `muladd`, `clenshaw_chebyshev` in [src/bessels_constants.f90](../src/bessels_constants.f90).
+- `cbrt` for `x^{2/3}` operations: `x**(2.0_BK/3.0_BK)` or `cbrt(x)**2`.
+
+## What's missing
+
+Everything — a new module [src/bessels_airy.f90](../src/bessels_airy.f90), wired into [src/bessels.f90](../src/bessels.f90) via `use bessels_airy` and re-export.
+
+## Approach — port [Bessels.jl/src/AiryFunctions/airy.jl](https://github.com/heltonmc/Bessels.jl/blob/master/src/AiryFunctions/airy.jl)
+
+Four argument regions, the same for `Ai` and `Bi` (with different coefficient tables):
+
+| Region | Method |
+|---|---|
+| `x ∈ [0, 2.06)` | Minimax polynomial / rational approximation (Cephes-derived). |
+| `x ≥ 2.06` | Tabulated asymptotic polynomial expansion: `Ai(x) ≈ exp(-ζ)/(2√π x^{1/4}) · P(1/ζ)` with `ζ = (2/3)x^{3/2}`. Bessels.jl pre-computed `P` coefficients in Mathematica/Arb. |
+| `x ∈ [-10, 0)` | Piecewise Taylor series around the Airy zeros. |
+| `x < -10` | Asymptotic with Euler-formula trick to stay in real arithmetic: `Ai(x) ≈ (1/√π)·|x|^{-1/4}·[cos(ζ+π/4)·P + sin(ζ+π/4)·Q]` where `ζ = (2/3)|x|^{3/2}`. |
+
+`Bi` uses the same branch structure but with sign flips and different coefficient tables; some intervals use `clenshaw_chebyshev`.
+
+**Derivatives** (`airyaiprime`, `airybiprime`) have their own coefficient tables — they are not numerical derivatives of the value functions. Bessels.jl computes them with the same branch structure.
+
+**Scaled variants** apply `exp(2/3 · x^{3/2})` (for Ai) or `exp(-2/3 · x^{3/2})` (for Bi). They **throw `DomainError` for negative x** in Bessels.jl — in Fortran return `ieee_quiet_nan` to match the existing convention (see `bessely0` for `x<0`).
+
+## Step-by-step
+
+1. **Create [src/bessels_airy.f90](../src/bessels_airy.f90).** Banner header, `use bessels_constants`, `private`, `public :: airyai, airyaiprime, airybi, airybiprime, airyaix, airyaiprimex, airybix, airybiprimex`.
+2. **Port the coefficient tables.** From Bessels.jl `src/AiryFunctions/airy.jl` — copy as `real(BK), parameter` arrays. These are tabulated and stable; mass-port them. Group by function (`AI_SMALL_P`, `AI_SMALL_Q`, `AI_LARGE_P`, `AI_NEG_P`, etc.) following the Julia naming.
+3. **`airyai(x)`** with the four branches. Each branch: a polynomial / rational call + a multiplicative prefactor. Use `cbrt` only where the cubic-root form is more accurate than `x**(1.0_BK/3.0_BK)` — they should be equivalent at `real64` but `cbrt` is what Bessels.jl uses for `x^{1/3}` integers-of-three exponents.
+4. **`airybi(x)`** — same structure, different tables. Watch the `clenshaw_chebyshev` intervals: pass the Chebyshev coefficients as the second arg to `clenshaw_chebyshev`.
+5. **`airyaiprime(x)`, `airybiprime(x)`** — separate coefficient sets, same branch structure.
+6. **Scaled variants** — pass `do_scale` as a boolean parameter? Bessels.jl has them as separate top-level functions; mirror that. For each, branch on `x < 0` → NaN, else compute as `airyai(x) * exp(2x^{3/2}/3)` for Ai (and analogous for Bi). The scaled variants exist because the unscaled `Ai(x)` underflows for `x > ~104` and `Bi(x)` overflows; the scaled versions stay finite.
+7. **Wire into [src/bessels.f90](../src/bessels.f90)**: `use bessels_airy`, add the eight functions to the `public` list.
+8. **Edge cases.** `x = 0`: `Ai(0) = 1/(3^{2/3} Γ(2/3))`, `Bi(0) = 1/(3^{1/6} Γ(2/3))`, `Ai'(0) = -1/(3^{1/3} Γ(1/3))`, `Bi'(0) = 3^{1/6}/Γ(1/3)`. The constants module already has `GAMMA_TWO_THIRDS` and `GAMMA_ONE_THIRD`. Bessels.jl returns these exactly without branching — verify the small-`x` polynomial reproduces them to within `eps()`.
+
+## Tests (add to [test/bessels_test.f90](../test/bessels_test.f90))
+
+- `test_airyai` — values at `x ∈ {-50, -10, -2, -0.5, 0, 0.5, 2, 10, 50}` against tabulated reference (Wolfram Alpha / Bessels.jl).
+- `test_airyaiprime`, `test_airybi`, `test_airybiprime` — same grid.
+- `test_airyai_zeros` — `Ai(a_k) = 0` for the first few Airy zeros (`a_1 ≈ -2.3381…`, `a_2 ≈ -4.0879…`); verify the negative-x branch is accurate near them.
+- `test_airyaix_overflow_guard` — `airyaix(100.0)` should be `O(1)` while `airyai(100.0)` underflows.
+- `test_airyai_cputime`, `test_airybi_cputime` — benchmark block.
+
+No netlib comparison — netlib `specfun` Airy is in `src/3rd_party/` only if we add it, and Bessels.jl avoids that route deliberately. Use tabulated reference values.
+
+## Done when
+
+- Eight Airy functions exported from `bessels`.
+- All test cases pass to `eps(BK) * 10` relative error on the value functions, `eps(BK) * 100` near zeros (zeros are inherently ill-conditioned).
+- Benchmarks added; ns/eval competitive with the rest of the library (Airy is polynomial-heavy → should be in the 20-40 ns/eval range).
+- README "Not yet implemented" loses four entries; "Currently available" gains eight (four + four scaled).

--- a/todo/03-besselk-variable-order.md
+++ b/todo/03-besselk-variable-order.md
@@ -1,0 +1,69 @@
+# 03 — `besselk(nu, x)` variable order
+
+## Goal
+
+Public `besselk(nu, x)` and scaled `besselkx(nu, x) = exp(x) · K_ν(x)`, both `elemental real(BK)`, real `nu` and `x`.
+
+This is the **largest** of the variable-order ports: it introduces two pieces of new numerical infrastructure (Temme series for K near integer order, and the K-specific Debye uniform asymptotic) that don't have analogues in the existing code.
+
+## What's already there
+
+- `besselk0(x)`, `besselk1(x)` in [src/bessels.f90](../src/bessels.f90) for the base cases of forward recurrence.
+- `gamma_BK` in [src/bessels_gamma.f90](../src/bessels_gamma.f90) for the Temme series.
+- `evalpoly`, `muladd`, `cbrt` utilities.
+- The `Uk_poly{5,10,20}` machinery in [src/bessels_debye.f90](../src/bessels_debye.f90) — note that these are the J/Y Debye polynomials. K_ν uses a **different** set of U-coefficients (NIST 10.41); we need to port those too. They share the same recursive structure but the leading-order behavior differs.
+
+## What's missing
+
+1. K-specific Debye uniform asymptotic expansion — call it `besselk_debye(nu, x)`. Distinct from `besseljy_debye`; see NIST DLMF 10.41 and Bessels.jl `src/BesselFunctions/U_polynomials.jl` (`Uk_poly_Kn`).
+2. Temme series for K near integer order — Bessels.jl `src/BesselFunctions/besselk.jl` `_K_nu_temme`. Handles the `0/0` cancellation when `ν → n` exactly via L'Hôpital-style limit.
+3. Large-x asymptotic `K_ν(x) ≈ √(π/(2x)) · e^{-x} · P(1/x)` (asymptotic series in `1/x`, coefficients functions of `ν`).
+4. Forward recurrence wrapper — `K_{n+1} = (2n/x) K_n + K_{n-1}` (note `+`, opposite sign from J's recurrence — both directions are stable for K because K grows downward).
+5. Public `besselk(nu, x)` dispatching across the four branches.
+6. Scaled `besselkx(nu, x)`.
+
+## Approach — port [Bessels.jl/src/BesselFunctions/besselk.jl](https://github.com/heltonmc/Bessels.jl/blob/master/src/BesselFunctions/besselk.jl)
+
+Four branches by `(nu, x)`:
+
+| Branch | Method |
+|---|---|
+| `x > nu²/36 + 18` | Large-x asymptotic series in `1/x`. |
+| `x > nu⁴/2401 + 1.5` (and not branch 1) | Levin-transform sequence acceleration on the asymptotic series. **Defer this — the other three branches cover most of parameter space; mark as a follow-up.** |
+| `nu > 25` or `x > 35` (and not above) | Debye uniform asymptotic via K-specific U-polynomials. |
+| Default (small `x`, moderate `nu`) | Temme series for non-integer `nu`; for integer `nu` use upward recurrence from `besselk0`/`besselk1`. |
+
+`K_{-ν} = K_ν` exactly — handle at the top with `nu = abs(nu)`, no reflection cost.
+
+`x ≤ 0`: NaN (matches `besselk0`'s convention).
+
+## Step-by-step
+
+1. **Negative-`nu` and edge cases.** Add the top-level dispatcher returning NaN for `x ≤ 0` and folding `nu = abs(nu)`.
+2. **Integer-`nu` fast path.** Use the existing `besselk0`/`besselk1` and upward recurrence `K_{n+1}(x) = (2n/x) K_n(x) + K_{n-1}(x)`. Add a helper `besselk_up_recurrence` mirroring `besselj_up_recurrence` in [src/bessels_constants.f90:843](../src/bessels_constants.f90#L843) — same shape, plus instead of minus in the recurrence. **Watch out** for the suspected bug in `besselj_up_recurrence` (see [06-housekeeping.md](06-housekeeping.md)) — don't propagate it.
+3. **Large-x asymptotic.** Port `K_large_argument` from Bessels.jl. The leading factor is `√(π/(2x)) · e^{-x}`; the series in `1/x` has coefficients `μ = 4ν²`, then `a_k = ∏(μ - (2j-1)²)/(k! · 8^k · x^k)`. For `besselkx`, drop the `e^{-x}` factor. Use Horner via `evalpoly`; the cutoff is when adding the next term would not change the sum to `eps(BK)`.
+4. **Temme series.** This is the non-trivial new component. Port from `_K_nu_temme` — it computes `K_ν` and `K_{ν+1}` for non-integer `ν` near zero, then can be upward-recurred. The series converges for `x ≤ 2`, and combines with downward recurrence for larger `x`. Key trick: a power-series representation of `K_ν` that stays accurate even as `ν → integer` (the singularity in `gamma(-ν)` cancels analytically).
+5. **K-specific Debye expansion.** Port `besselk_debye` (and its U-polynomial table) from `U_polynomials.jl`. The same `Uk_poly_{5,10,20}` shape applies but with the K-flavored coefficients. **Plan to share infrastructure with [04-besseli-variable-order.md](04-besseli-variable-order.md)** — `besseli_debye` uses the *same* U-table (just a different prefactor). Put the new K-flavored U-polys in [src/bessels_debye.f90](../src/bessels_debye.f90) next to the existing J/Y ones, or split into `bessels_debye_ki.f90` if the file gets unwieldy.
+6. **Dispatcher.** Branch as per the table above. Add cutoff helpers `besselk_debye_cutoff`, `besselk_large_arg_cutoff` mirroring the existing `besseljy_debye_cutoff64` etc.
+7. **`besselkx`.** Same dispatcher; in each branch skip or add back the `e^{±x}` factor as appropriate.
+
+## New files / file changes
+
+- [src/bessels_besselk.f90](../src/bessels_besselk.f90) — new module hosting `besselk_debye`, `besselk_temme_series`, `besselk_large_argument`, and the public `besselk` / `besselkx`. Keeps [src/bessels.f90](../src/bessels.f90) from ballooning.
+- [src/bessels_debye.f90](../src/bessels_debye.f90) — add K U-polynomial tables.
+- [src/bessels.f90](../src/bessels.f90) — `use bessels_besselk`, export `besselk`, `besselkx`.
+
+## Tests
+
+- `test_besselk_nu` — values at `(nu, x)` grid `nu ∈ {0.0, 0.5, 1.0, 2.5, 5.0, 30.0, 100.0}`, `x ∈ {0.01, 0.1, 1.0, 5.0, 20.0, 100.0, 500.0}`. Compare against `besselk0`/`besselk1` for `nu=0/1`, against netlib `rkbesl` (already in [src/3rd_party/](../src/3rd_party/)) for integer `nu`, and against tabulated reference for non-integer.
+- `test_besselk_temme` — focused on `x < 2`, `nu ∈ {0.1, 0.4, 0.99, 1.01, 2.0001}` — verify the near-integer limit doesn't blow up.
+- `test_besselk_debye` — `nu = 100`, `x ∈ {5, 50}` — verify the Debye branch is active and accurate.
+- `test_besselkx_overflow` — `besselkx(0.0, 700.0)` should be finite (~`√(π/1400)`) while `besselk(0.0, 700.0)` underflows to zero.
+- `test_besselk_nu_cputime` benchmark.
+
+## Done when
+
+- `besselk(nu, x)` and `besselkx(nu, x)` exported from `bessels`.
+- Tests pass; netlib comparison shows we're at least as fast (current `besselk0/1` are ~5-6 ns/eval — variable-order will be slower, target `<30 ns/eval` for `besselk_debye` branch).
+- The K U-polynomial machinery is shared with the upcoming `besseli` port.
+- Levin acceleration deferred to a follow-up TODO; document the cutoff gap (region between "large-x asymptotic" and "Debye" where accuracy may be ~1 ulp worse).

--- a/todo/04-besseli-variable-order.md
+++ b/todo/04-besseli-variable-order.md
@@ -1,0 +1,86 @@
+# 04 — `besseli(nu, x)` variable order
+
+## Goal
+
+Public `besseli(nu, x)` and scaled `besselix(nu, x) = exp(-x) · I_ν(x)`, both `elemental real(BK)`.
+
+## Dependency
+
+**Requires [03-besselk-variable-order.md](03-besselk-variable-order.md) to be done first** — `I_ν(x)` for negative `ν` uses the reflection `I_{-ν}(x) = I_ν(x) + (2/π) sin(πν) K_ν(x)`. Without `besselk(nu, x)` this branch is unimplementable.
+
+The K-port also produces a U-polynomial table for Debye that `besseli_debye` reuses — coordinate the file layout so both modules share it.
+
+## What's already there
+
+- `besseli0(x)`, `besseli1(x)` in [src/bessels.f90](../src/bessels.f90).
+- `gamma_BK` for the power series.
+- `evalpoly`, `muladd`.
+- After [03](03-besselk-variable-order.md) lands: `besselk(nu, x)` for the reflection, plus shared U-polynomial table.
+
+## What's missing
+
+1. I-specific Debye uniform asymptotic — same U-polynomial table as `besselk` but with a different prefactor and an additive sign (NIST 10.41.E3 vs 10.41.E4).
+2. Power series for small `x` — `I_ν(x) = (x/2)^ν · Σ (x/2)^{2k} / (k! · Γ(ν+k+1))`.
+3. Large-x asymptotic — `I_ν(x) ≈ e^x/√(2πx) · P(1/x)`, where the series coefficients are signed versions of K's (related by `(−1)^k`). Can largely be derived from the K port.
+4. Public `besseli(nu, x)` dispatcher.
+5. `besselix(nu, x)` — scaled variant, the practically important one for large x.
+
+## Approach — port [Bessels.jl/src/BesselFunctions/besseli.jl](https://github.com/heltonmc/Bessels.jl/blob/master/src/BesselFunctions/besseli.jl)
+
+### Negative arguments and orders
+
+Up front in the dispatcher (before any computation):
+
+```fortran
+if (nu == real(int(nu), BK) .and. x < ZERO) then
+    ! integer nu, negative x: I_n(-x) = (-1)^n I_n(x)
+    besseli = besseli(nu, -x) * (1 - 2*mod(int(abs(nu)), 2))
+elseif (nu /= real(int(nu), BK) .and. x < ZERO) then
+    besseli = ieee_value(besseli, ieee_quiet_nan)   ! domain error
+elseif (nu < ZERO) then
+    ! I_{-ν}(x) = I_ν(x) + (2/π) sin(πν) K_ν(x)
+    besseli = besseli_positive_args(-nu, x) + TWOOPI * sin(-PI*nu) * besselk(-nu, x)
+else
+    besseli = besseli_positive_args(nu, x)
+end if
+```
+
+### Positive-`nu` branches
+
+| Branch | Method |
+|---|---|
+| Large `x` and not too large `nu` | Asymptotic series in `1/x`, leading factor `e^x / √(2πx)`. |
+| Large `nu` or moderate `x` with `nu ≳ x` | Debye uniform asymptotic via I-flavored U-polynomial expansion. |
+| Default (small `x`, moderate `nu`) | Power series. |
+| Integer `nu`, moderate `x` | Forward recurrence from `besseli0`/`besseli1` using `I_{n+1}(x) = I_{n-1}(x) - (2n/x) I_n(x)` (note: this is the *downward* relation; upward is unstable for I, so for moderate `nu < ~x` use forward, otherwise use the asymptotic branches). Bessels.jl uses a hybrid approach — check the Julia for the exact cutoff. |
+
+### Scaled variant `besselix(nu, x)`
+
+In each branch, factor out `e^x` or `e^{-x}` to keep the result `O(1)` for large `x`. The asymptotic branch naturally has `e^x` separable; the Debye branch produces a `nu·η(p)` exponential that combines cleanly with `e^{-x}` for the scaled form. The power series branch should reconstruct `e^{-x}·I_ν(x)` for `besselix` rather than computing `besseli` and multiplying — cheap with `exp(-x)` applied once after the sum.
+
+## Step-by-step
+
+1. **Pre-flight.** Verify [03](03-besselk-variable-order.md) is done and the shared U-polynomial table is in [src/bessels_debye.f90](../src/bessels_debye.f90) or a shared module.
+2. **New module** [src/bessels_besseli.f90](../src/bessels_besseli.f90) — parallel to `bessels_besselk`.
+3. **Power series.** Port `besseli_power_series`. Cancellation is minimal because all terms have the same sign — Horner-style accumulation is fine.
+4. **Large-x asymptotic.** Port `besseli_large_argument`. The coefficient series is the *unsigned* version of K's (`(μ - 1²)(μ - 3²)…` with `+` between consecutive products instead of `-`). Worth a helper `compute_I_K_asymptotic_coefs(nu)` shared with the K module.
+5. **Debye expansion.** Port `besseli_debye`. Same U-table as K, different prefactor `exp(ν·η(p)) · √(p / (2π·ν))` where `p = 1/√(1 + (x/ν)²)`, `η(p) = √(1+(x/ν)²) + log((x/ν)/(1 + √(1+(x/ν)²)))`. For the scaled variant, the `exp(ν·η - x)` combines.
+6. **Recurrence.** Forward `besseli_up_recurrence` from `besseli0`, `besseli1` for integer `nu`, gated by a `nu < x_cutoff` check (forward recurrence is stable only when `nu ≪ x`; otherwise use downward Miller recurrence or the Debye branch).
+7. **Dispatcher.** Wire branches per the table above. Add cutoff helpers `besseli_debye_cutoff`, `besseli_large_arg_cutoff`.
+8. **Wire into `bessels.f90`.** `use bessels_besseli`, export `besseli`, `besselix`.
+
+## Tests
+
+- `test_besseli_nu` — `(nu, x)` grid analogous to the K test. Compare against `besseli0`/`besseli1`, netlib `ribesl`, and tabulated reference.
+- `test_besseli_negative_nu_reflection` — `besseli(-2.5_BK, x)` must agree with the closed-form reflection involving `besselk(2.5_BK, x)` to `eps(BK) * 10`.
+- `test_besseli_integer_negative_x` — `besseli(3, -2.0_BK) == -besseli(3, 2.0_BK)` (odd `n`), `besseli(2, -2.0_BK) == besseli(2, 2.0_BK)` (even `n`).
+- `test_besseli_non_integer_negative_x_nan` — `besseli(2.5_BK, -1.0_BK)` returns NaN.
+- `test_besselix_no_overflow` — `besselix(0.0_BK, 700.0_BK)` finite while `besseli(0.0_BK, 700.0_BK)` overflows to `+Inf`.
+- `test_besseli_nu_cputime`.
+
+## Done when
+
+- `besseli`, `besselix` exported.
+- All four argument-domain branches (positive/negative `x`, integer/non-integer `nu`) covered with tests.
+- Negative-`nu` reflection through `besselk` produces machine-precision agreement at integer-`nu` limits.
+- Netlib `ribesl` benchmark shows >10x speedup at `nu=2.5, x=10` (current `besseli0` already beats netlib `ribesl` by ~200x; variable order will be slower per call but should still be dominant).

--- a/todo/05-spherical-bessels.md
+++ b/todo/05-spherical-bessels.md
@@ -1,0 +1,86 @@
+# 05 — Spherical Bessel functions
+
+## Goal
+
+Public `sphericalbesselj(nu, x)`, `sphericalbessely(nu, x)`, `sphericalbesseli(nu, x)`, `sphericalbesselk(nu, x)` — all `elemental real(BK)`.
+
+These are half-integer-order rescalings of the regular Bessels:
+- `j_n(x) = √(π/(2x)) · J_{n+1/2}(x)`
+- `y_n(x) = √(π/(2x)) · Y_{n+1/2}(x)`
+- `i_n(x) = √(π/(2x)) · I_{n+1/2}(x)`
+- `k_n(x) = √(2/(πx)) · K_{n+1/2}(x)`  (note: different prefactor)
+
+For integer `n` they have closed forms in elementary functions for small `n` (which is most of the practical use).
+
+## Dependencies
+
+- `sphericalbesselj/y` need `besselj(nu, x)` / `bessely(nu, x)` for non-integer `n` — see [01](01-wire-existing-variable-order.md).
+- `sphericalbesseli` needs `besseli(nu, x)` — [04](04-besseli-variable-order.md).
+- `sphericalbesselk` needs `besselk(nu, x)` — [03](03-besselk-variable-order.md).
+
+For **integer** `n` we can sidestep the half-integer Bessel dependency entirely via the closed forms below — so if [03] and [04] are delayed, an integer-only version of all four spherical functions ships first.
+
+## What's already there
+
+Nothing spherical. All the dependencies are tracked in other tier files.
+
+## Approach — port [Bessels.jl/src/BesselFunctions/sphericalbessel.jl](https://github.com/heltonmc/Bessels.jl/blob/master/src/BesselFunctions/sphericalbessel.jl) and [modifiedsphericalbessel.jl](https://github.com/heltonmc/Bessels.jl/blob/master/src/BesselFunctions/modifiedsphericalbessel.jl)
+
+### Integer `n` fast paths (no Bessel dependency)
+
+Base cases:
+- `j_0(x) = sin(x)/x`, `j_1(x) = sin(x)/x² − cos(x)/x`
+- `y_0(x) = −cos(x)/x`, `y_1(x) = −cos(x)/x² − sin(x)/x`
+- `i_0(x) = sinh(x)/x`, `i_1(x) = (x cosh(x) − sinh(x))/x²`
+- `k_0(x) = e^{−x}/x`, `k_1(x) = (1/x + 1/x²) · e^{−x}`
+
+Recurrence (same shape for all four):
+`f_{n+1}(x) = (2n+1)/x · f_n(x) − f_{n−1}(x)`  (for j, y, modified-i)
+`f_{n+1}(x) = (2n+1)/x · f_n(x) + f_{n−1}(x)`  (for k — sign flip)
+
+**Stability:** forward recurrence is stable for `y_n` (any `x`) and for `k_n` (any `x`), and for `j_n` / `i_n` when `n < x` — same considerations as the regular Bessels. For `j_n` with `n > x` use either backward Miller recurrence or fall through to `besselj(n+1/2, x)` once [01](01-wire-existing-variable-order.md) is done.
+
+### Cutoffs per Bessels.jl
+
+- Integer `n < 250` and `x ≥ n`: forward recurrence.
+- Integer `n < 60` and `x < n`: combine forward `y_n` recurrence with a continued-fraction `j_n/j_{n+1}` and the Wronskian `j_n y_{n+1} − j_{n+1} y_n = 1/x²` to recover `j_n`.
+- Otherwise: half-integer reduction via `besselj_positive_args(n + 0.5, x)`.
+- Very small `x`: power series `j_n(x) = x^n/(2n+1)!! · (1 − x²/(2(2n+3)) + …)` to avoid `sin(x)/x` cancellation.
+
+### Modified spherical (i, k) — [modifiedsphericalbessel.jl](https://github.com/heltonmc/Bessels.jl/blob/master/src/BesselFunctions/modifiedsphericalbessel.jl)
+
+- `i_n`: closed-form `sinh/cosh` expressions for `n ∈ {0,1,2}`, power series for small `x`, else half-integer reduction through `besseli(n+1/2, x)`.
+- `k_n`: forward recurrence from explicit `k_0`, `k_1` for `n < 41.5`. Otherwise `√(π/(2x)) · K_{n+1/2}(x)`. Negative `n` maps via `k_{−n}(x) = k_{n−1}(x)`.
+
+### Real `nu` (non-integer)
+
+Always reduces to the half-integer rescaling:
+```
+sphericalbesselj(nu, x) = sqrt(PIO2/x) * besselj(nu + HALF, x)
+```
+…and analogously for the other three. No new code beyond the prefactor.
+
+## Step-by-step
+
+1. **New module** [src/bessels_spherical.f90](../src/bessels_spherical.f90), `use bessels_constants`, `use bessels` (for `besselj_positive_args`, `bessely_positive_args`, `besseli`, `besselk` once they're public — make them so).
+2. **`sphericalbesselj_int(n, x)`** — closed-form `n=0`, recurrence for `n < min(250, x)`, continued-fraction + Wronskian for `n > x` and `n < 60`, else half-integer reduction.
+3. **`sphericalbessely_int(n, x)`** — closed-form `n=0,1`, forward recurrence from `y_0, y_1`.
+4. **`sphericalbesseli_int(n, x)`, `sphericalbesselk_int(n, x)`** — same shape.
+5. **Public elemental `sphericalbesselj(nu, x)`** dispatches: if `nu == real(int(nu), BK) .and. nu >= 0` → integer fast path; else `sqrt(PIO2/x) * besselj_positive_args(nu + HALF, x)` (with sign/domain handling for `x < 0` via parity).
+6. **Domain.** `x = 0` limits: `j_0(0) = 1`, `j_{n≥1}(0) = 0`, `y_n(0) = -∞` for all `n`, `i_0(0) = 1`, `i_{n≥1}(0) = 0`, `k_n(0) = +∞`. Match the Bessels.jl values exactly.
+7. **Wire into `bessels.f90`.** Export the four functions.
+
+## Tests
+
+- `test_sphericalbesselj` — `n ∈ {0, 1, 5, 50}`, `x ∈ {1.0, 10.0, 100.0}` against tabulated reference and against `sin(x)/x`-style closed forms for low `n`.
+- `test_sphericalbessely_recurrence_stability` — `n ∈ {0..60}`, `x = 1.0` — verify `y_n` grows monotonically and never NaN.
+- `test_sphericalbesseli`, `test_sphericalbesselk` — analogous.
+- `test_sphericalbessel_half_integer_consistency` — verify `sphericalbesselj(5.5, x) == sqrt(PIO2/x) * besselj(6.0, x)` to `eps(BK) * 10` (this checks the dispatcher routes through `besselj_positive_args` correctly).
+- Benchmarks for all four.
+
+## Done when
+
+- Four spherical functions exported.
+- Integer-`n` fast paths verified independent of the dependencies (they don't require `besselj/y/i/k` of fractional order).
+- Half-integer reduction tested once those dependencies are public.
+- README "Not yet implemented" loses four entries.

--- a/todo/06-housekeeping.md
+++ b/todo/06-housekeeping.md
@@ -1,0 +1,79 @@
+# 06 — Housekeeping & suspected bugs
+
+Small fixes, leftover TODOs, and one bug found during the audit. None of these block the variable-order work, but they should land alongside it.
+
+## 1. `besselj_up_recurrence` — suspected bug
+
+[src/bessels_constants.f90:843-871](../src/bessels_constants.f90#L843)
+
+```fortran
+elemental subroutine besselj_up_recurrence(x, jnu, jnum1, nu_start, nu_end, a, b)
+    ...
+    nu   = nu_start
+    do while (nu<nu_end+HALF)
+        jnu2 = [jnu2(2), nu_start*x2*jnu2(2) - jnu2(1)]   ! ← nu_start, not nu
+        nu = nu-ONE                                          ! ← decrement, not increment
+    end do
+```
+
+Forward recurrence for J/Y is `f_{n+1} = (2n/x)·f_n − f_{n−1}`. The coefficient should be `2n/x = nu * x2` where `nu` increases each iteration — but the code uses the *fixed* `nu_start` and *decrements* `nu`. That makes the `while (nu<nu_end+HALF)` condition only true if `nu_start < nu_end`, in which case the loop never advances `nu` toward termination (it goes the wrong way) → infinite loop, **or** the loop runs once and returns the wrong value.
+
+**Why it's not blowing up today**: `besselj_up_recurrence` is only called from `bessely_positive_args` (integer `nu` fast path) and `bessely_chebyshev`. The integer-`nu` path calls with `nu_start = ONE, nu_end = nu` — when `nu == 1` the loop body runs once (with the wrong coefficient, but for a degenerate case it produces the right answer) and exits. For `nu > 1` the test suite would catch it — except `test_bessel_y0`/`y1` don't actually exercise variable-order Y, and `bessely(nu, x)` isn't public yet, so the bug is dormant.
+
+**Fix:** replace `nu_start` with `nu` inside the loop and increment `nu = nu + ONE`. Add a regression test that compares `besselj_up_recurrence(x, j1, j0, 1.0, 5.0, ...)` against five forward applications of the recurrence by hand.
+
+**Cross-check the down recurrence**: [src/bessels_constants.f90:822-837](../src/bessels_constants.f90#L822) `besselj_down_recurrence` uses `nus*x2*jnu2(2)-jnu2(1)` with `nus = nu_start` then `nus = nus-ONE` — but it's down-recurrence (`nu_start > nu_end`) so the coefficient should decrease each step, which `nus = nus - ONE` does. The down version looks correct; only the up version is broken.
+
+This must be fixed **before** [01-wire-existing-variable-order.md](01-wire-existing-variable-order.md) ships, because `bessely(nu, x)` will route integer-`nu` calls through this broken recurrence.
+
+## 2. Four in-code `TODO` comments
+
+[src/bessels.f90](../src/bessels.f90):
+
+- Line 488: `! TODO: replace the two polynomials with a single one` (in `bessely0`, small-x branch)
+- Line 497: same TODO in `bessely0`, mid-x branch
+- Line 560: same TODO in `bessely1`
+- Line 570: same TODO in `bessely1`
+
+These are about rational-function `P/Q` evaluations where `P` and `Q` are evaluated independently then divided. The TODO suggests fusing into a single evaluation. **Defer** unless benchmarks show `bessely0/y1` are hot in caller workloads — they're already at 17-18 ns/eval (faster than the gfortran intrinsic). Convert to GitHub issues or strike out if not pursuing.
+
+## 3. `gamma_BK` not re-exported
+
+[src/bessels.f90](../src/bessels.f90) does not `use bessels_gamma`. The README implies `gamma_BK` is part of the package's API, and the test file does `use bessels_gamma` directly to get at it. This split is awkward. Pick one:
+
+- **Re-export from `bessels`** (recommended): add `use bessels_gamma, only: gamma_BK` and `public :: gamma_BK`. One-line change, no behavioral risk. Bundled with [01-wire-existing-variable-order.md](01-wire-existing-variable-order.md).
+- **Or split clearly** — document that math helpers live in `bessels_gamma` and update the README accordingly.
+
+Going with the re-export keeps `use bessels` as the single entry point.
+
+## 4. `Uk_poly_Hankel` — leftover comment
+
+[src/bessels_debye.f90:76](../src/bessels_debye.f90#L76):
+
+```fortran
+ab    = Uk_poly_Hankel(p, nu, -p2, x) ! why p*im ?
+```
+
+Someone (Federico?) left a confused comment while porting. `hankel_debye` produces a complex output and the U-polynomial values are split into the real/imaginary parts via `split_evalpoly` — the `-p2` argument is correct (the alternating-sign split). The `p*im` reference in the comment is a Julia-ism that didn't translate; the Fortran path computes `Uk_Yn = IM * ab(2)` on line 77 which is the correct construction. **Delete the comment.**
+
+## 5. Multi-precision cutoffs declared but unused
+
+[src/bessels_constants.f90](../src/bessels_constants.f90) has `besseljy_debye_cutoff32`, `besseljy_debye_cutoff128`, `bessely_series_cutoff32`, `besselj_series_cutoff128` etc. — `real32` and `real128` variants of every cutoff. None are wired up because `BK` is fixed to `real64`. Either:
+
+- Keep them (low cost, signals future multi-precision intent — the `! Todo: make one module per real precision` comment at [src/bessels.f90:24](../src/bessels.f90#L24) confirms the intent).
+- Move to a `bessels_constants_multi.f90` to keep the `real64` module lean.
+
+**Defer**. Revisit when a multi-precision branch actually starts.
+
+## Step-by-step
+
+1. Fix `besselj_up_recurrence` (item 1). Add the regression test. Run the existing test suite to confirm nothing else regresses.
+2. Add `use bessels_gamma, only: gamma_BK` and `public :: gamma_BK` to [src/bessels.f90](../src/bessels.f90) (item 3). Update the test file to `use bessels` only for `gamma_BK`.
+3. Delete the stray `! why p*im ?` comment (item 4).
+4. Decide on items 2 and 5; either fix or close as won't-fix and remove the inline TODOs.
+
+## Done when
+
+- `besselj_up_recurrence` produces correct values for `nu > 1`, verified by direct comparison.
+- `gamma_BK` reachable via `use bessels`.
+- Cleanup PR is small and surgical — no behavioral changes to anything other than `besselj_up_recurrence`.

--- a/todo/07-nonintegerNU-bugs.md
+++ b/todo/07-nonintegerNU-bugs.md
@@ -1,0 +1,121 @@
+# 07 — Pre-existing bugs in non-integer-ν paths
+
+## Goal
+
+Fix three port bugs in [src/bessels.f90](../src/bessels.f90), [src/bessels_constants.f90](../src/bessels_constants.f90), and [src/bessels_debye.f90](../src/bessels_debye.f90) that make `bessely(non-integer nu, x)` return wildly wrong values. The public `bessely(nu, x)` wrapper shipped in [01-wire-existing-variable-order.md](01-wire-existing-variable-order.md) is correct for integer ν only because of these bugs.
+
+## Discovered when
+
+Implementing plan 01 — added a half-integer reference test for `bessely(nu, x)` against the closed-form `Y_{1/2}/Y_{3/2}/Y_{5/2}` identities. Every single non-integer test case failed by 1-3 orders of magnitude. Walking through the call graph revealed three distinct port bugs.
+
+The integer-ν path was unaffected (and still is) because it routes exclusively through `besselj_up_recurrence` from `bessely0/bessely1`, which doesn't touch any of the buggy helpers.
+
+## Bug 1 — `bessely_power_series` argument order swap
+
+[src/bessels_constants.f90:762](../src/bessels_constants.f90#L762):
+
+```fortran
+pure function bessely_power_series(x, nu) result(YJ)
+   real(BK), intent(in) :: x, nu
+```
+
+[src/bessels.f90:424](../src/bessels.f90#L424):
+
+```fortran
+YJ = bessely_power_series(nu, x)   ! ← caller passes (nu, x), function signature is (x, nu)
+```
+
+The function body uses its local `x` as the argument (in `xo2 = HALF*x`) and local `nu` as the order (in `xo2**nu`). With the swap, the function computes `Y_{x_caller}(nu_caller)` instead of `Y_{nu_caller}(x_caller)`.
+
+The Julia source has signature `bessely_power_series(v, x)` (v = nu first). The Fortran signature should be `(nu, x)` — but the call site is correct and the signature is wrong. Easier fix: swap the signature.
+
+**Fix:** rename the parameters and/or swap in either the caller or the signature. Recommended:
+
+```fortran
+pure function bessely_power_series(nu, x) result(YJ)
+   real(BK), intent(in) :: nu, x
+```
+
+(matches the Julia and the call site).
+
+## Bug 2 — `bessely_chebyshev` mapping mismatch
+
+[src/bessels.f90:415](../src/bessels.f90#L415):
+
+```fortran
+elemental complex(BK) function bessely_chebyshev(nu, x) result(cheb)
+   ...
+   nu_floor = nu - int(nu)
+   Y = bessely_chebyshev_low_orders(nu_floor, x)
+   call besselj_up_recurrence(x, Y%im, Y%re, nu_floor + ONE, nu, cheb%re, cheb%im)
+```
+
+`bessely_chebyshev_low_orders` returns a pair packed as `cheb%re, cheb%im` from `clenshaw(nu - 1, ...)` and `clenshaw(nu, ...)`. The recurrence then expects `(jnu at order nu_start-1, jnup1 at order nu_start)`. The current code passes `Y%im` first and `Y%re` second — these are at orders that don't match `nu_start = nu_floor + 1`.
+
+This needs careful comparison to the Julia source (`src/BesselFunctions/bessely.jl` in Bessels.jl) to determine the correct argument ordering and the actual chebyshev table convention. Specifically:
+- What range of `nu` does the table represent?
+- Does `clenshaw_chebyshev(p, a)` evaluate at orderindex `p`, at `p + offset`, or at a normalized chebyshev point?
+- In what order should the two table evaluations feed the recurrence?
+
+Once that's pinned down, the fix is likely 1-2 lines. The recurrence itself is now correct (post-plan-06 bug fix) — only the call site needs adjustment.
+
+## Bug 3 — `hankel_debye` complex-output truncation
+
+[src/bessels_debye.f90:57-81](../src/bessels_debye.f90#L57):
+
+```fortran
+ab    = Uk_poly_Hankel(p, nu, -p2, x) ! why p*im ?
+Uk_Yn = IM*ab(2)
+hankel_debye = coef_Yn * Uk_Yn
+```
+
+The Julia source:
+
+```julia
+_, Uk_Yn = Uk_poly_Hankel(p*im, v, -p², T(x))
+return coef_Yn * Uk_Yn
+```
+
+Two differences:
+1. Julia passes `p*im` (complex first argument) to `Uk_poly_Hankel`. Fortran passes real `p`. The downstream `split_evalpoly` therefore can't reconstruct the correct complex polynomial value.
+2. Even discarding the `*im` issue, the Fortran combines as `Uk_Yn = IM*ab(2)` (purely imaginary). Julia uses the second return directly, with `ab(2)` already a complex value from the complex polynomial evaluation.
+
+For ν=0 inputs this also divides by zero (`-p/v = -0/0 = NaN`) in `Uk_poly{10,20}_split`, producing NaN outputs that leak through the test suite as `sum(z)=NaN`.
+
+**Fix scope:** larger. `Uk_poly_Hankel` and the underlying `split_evalpoly` need a complex-argument variant. Either:
+- Add a parallel `Uk_poly_Hankel_complex` returning `complex(BK)` for the Hankel-specific path, or
+- Generalize the existing real path to accept and return complex via two real components, matching the Julia trick where (a, b) = real and imaginary parts of `poly(i*p)` evaluated by the even/odd split.
+
+The Bessels.jl `split_evalpoly` in `Math.jl` shows the exact arithmetic — port that carefully.
+
+**Workaround in shipped plan 01:** `besselh` was modified to bypass `hankel_debye` entirely (always uses `J + i·Y` composition). This makes `besselh(integer ν, x)` correct at all `x`, at the cost of speed in the large-x regime where `hankel_debye` was designed to be the fast path. `bessely_positive_args` still routes to `aimag(hankel_debye(...))` for non-integer ν in some x ranges — so non-integer `bessely(nu, x)` is still broken via this path too.
+
+## Step-by-step
+
+1. **Bug 1 first** — it's a one-liner swap. Verify by enabling the `test_bessely_nu_half_integer` test (removed in plan 01's restricted form) and confirming all `Y_{1/2}/Y_{3/2}/Y_{5/2}` cases pass at `x ∈ {0.5, 2.0}` (the power-series branch).
+2. **Bug 2** — needs Julia-source comparison. Cross-check the table convention by computing a single chebyshev value by hand against `bessely(0.5, 7.0)` (a known value via closed form). Then fix the call.
+3. **Bug 3** — port `Uk_poly_Hankel` with proper complex polynomial evaluation. Re-enable the `hankel_debye` fast path in `besselh` once verified. Add a `test_hankel_debye_correctness` test that compares `hankel_debye(nu, x)` to `cmplx(besselj_positive_args(nu, x), bessely_positive_args(nu, x))` for non-integer ν across the cutoff regions.
+4. **Re-add the suppressed tests** in [test/bessels_test.f90](../test/bessels_test.f90): the half-integer ν test and a negative-ν Hankel reflection test (both removed in plan 01's restricted form to keep CI green).
+5. **Restore the hankel_debye fast path** in `besselh` — search for the `! Implementation note:` comment block in [src/bessels.f90](../src/bessels.f90) and restore the `if (hankel_debye_cutoff(...)) then H = hankel_debye(...)` branch.
+
+## Tests to re-enable / add
+
+Removed from plan 01 to ship a clean suite:
+- `test_bessely_nu_half_integer` — closed-form `Y_{1/2}/Y_{3/2}/Y_{5/2}`. Cover `x ∈ {0.5, 2.0, 7.0, 30.0, 100.0}` so each branch is exercised.
+- `test_hankelh_negative_nu` — verify `H^(1)_{-ν}(x) = exp(+iπν)·H^(1)_ν(x)` for `ν ∈ {0.5, 2.5}`, `x = 5.0`.
+
+New:
+- `test_bessely_nu_chebyshev` — focused on `x ∈ (6, 19)` where the chebyshev branch is active.
+- `test_hankel_debye_consistency` — direct check of `hankel_debye(nu, x)` vs `J + i·Y` for `(ν, x)` covering both Uk_poly10 and Uk_poly20 regimes.
+
+## Done when
+
+- All three bugs are fixed, with regression tests demonstrating each.
+- The `besselh` workaround (bypass `hankel_debye`) is removed; the fast path is restored.
+- `bessely(non-integer nu, x)` agrees with closed-form / tabulated reference to `eps(BK) * 100` across all branches.
+- The suppressed tests are restored and pass.
+
+## References
+
+- Plan 01: [01-wire-existing-variable-order.md](01-wire-existing-variable-order.md) — where these bugs surfaced
+- Bessels.jl reference: `src/BesselFunctions/bessely.jl`, `src/BesselFunctions/U_polynomials.jl`, `src/Math/Math.jl`

--- a/todo/README.md
+++ b/todo/README.md
@@ -23,6 +23,7 @@ This means **Tier 0** below is mostly plumbing.
 | 3  | [04-besseli-variable-order.md](04-besseli-variable-order.md) | medium | Depends on K_ν. Power series + Debye + large-x asymptotic + scaled variant `besselix`. |
 | 4  | [05-spherical-bessels.md](05-spherical-bessels.md) | medium | Needs Tier 0–3 done. Mix of integer-order fast paths (sin/cos/sinh/cosh closed forms) and half-integer fallback. |
 | 5  | [06-housekeeping.md](06-housekeeping.md) | small | Four in-code TODOs in `bessely0`/`bessely1`, suspected bug in `besselj_up_recurrence`, `Uk_poly_Hankel` "why p*im?" comment. |
+| 6  | [07-nonintegerNU-bugs.md](07-nonintegerNU-bugs.md) | medium | Three port bugs (`bessely_power_series` arg swap, `bessely_chebyshev` mapping, `hankel_debye` complex output) surfaced while implementing plan 01. `bessely(nu, x)` and `besselh` ship correct for integer ν only until this lands. |
 
 ## Out of scope (matching Bessels.jl's public API)
 

--- a/todo/README.md
+++ b/todo/README.md
@@ -1,0 +1,45 @@
+# Implementation Roadmap
+
+Prioritized plans for the functions still missing from the public API, based on what's already implemented internally and what dependencies each new function brings.
+
+## State of the codebase (audit, 2026-05-27)
+
+**Public API today** — [src/bessels.f90](../src/bessels.f90) exports `besselj0/j1/jn`, `bessely0/y1`, `besselk0/k1`, `besseli0/i1`, plus `cbrt` / constants. `gamma_BK` lives in [src/bessels_gamma.f90](../src/bessels_gamma.f90) but is **not** re-exported from `bessels` — users have to `use bessels_gamma` separately, which contradicts the README.
+
+**Hidden assets** — already implemented as private helpers but not exported:
+- `besselj_positive_args(nu, x)`, `bessely_positive_args(nu, x)` — full variable-order J/Y machinery (debye + large-arg + hankel + series + recurrence branches).
+- `hankel_debye(nu, x) -> complex(BK)` — full Hankel implementation for `x > ~nu`.
+- All `Uk_poly{5,10,20}` Debye U-polynomial tables, `besseljy_debye`, `besseljy_large_argument`, `clenshaw_chebyshev`, `bessely_chebyshev*`, power series for J/Y, up/down recurrences.
+
+This means **Tier 0** below is mostly plumbing.
+
+## Suggested order
+
+| #  | Plan | Effort | Why this order |
+|----|------|--------|----------------|
+| 0  | [01-wire-existing-variable-order.md](01-wire-existing-variable-order.md) | small | Ship `bessely(nu,x)`, `besselh`, `hankelh1/2`, re-export `gamma_BK` — most of the work is already done. |
+| 1  | [02-airy.md](02-airy.md) | medium | Fully independent of Bessel routines (Bessels.jl uses Cephes-style minimax polys, not K_{1/3}). Can land anytime. |
+| 2  | [03-besselk-variable-order.md](03-besselk-variable-order.md) | large | New infrastructure: Temme series + uniform asymptotic for K_ν. `besseli(nu,x)` depends on it for negative-ν reflection. |
+| 3  | [04-besseli-variable-order.md](04-besseli-variable-order.md) | medium | Depends on K_ν. Power series + Debye + large-x asymptotic + scaled variant `besselix`. |
+| 4  | [05-spherical-bessels.md](05-spherical-bessels.md) | medium | Needs Tier 0–3 done. Mix of integer-order fast paths (sin/cos/sinh/cosh closed forms) and half-integer fallback. |
+| 5  | [06-housekeeping.md](06-housekeeping.md) | small | Four in-code TODOs in `bessely0`/`bessely1`, suspected bug in `besselj_up_recurrence`, `Uk_poly_Hankel` "why p*im?" comment. |
+
+## Out of scope (matching Bessels.jl's public API)
+
+- Scaled variants `besseli0x`, `besselix`, `besselk0x`, `besselkx`, `airyaix`, etc. — fold into each tier as the unscaled version lands.
+- In-place sequence variants (`besselj!`, `bessely!`, …) — useful for HPC callers; revisit after the scalar API is complete.
+- Complex Airy (`cairy.jl`) and complex-argument ordinary Bessels — **not** in Bessels.jl's stable public API; defer indefinitely.
+
+## How each plan is structured
+
+Each file follows the same shape:
+
+1. **Goal** — one sentence, what the public-facing change is.
+2. **What's already there** — concrete file/function references for code we can reuse.
+3. **What's missing** — what we have to write or port.
+4. **Approach** — branch structure, citing the Julia reference file.
+5. **Step-by-step** — numbered, each step verifiable.
+6. **Tests** — what to add to `test/bessels_test.f90`.
+7. **Done when** — measurable success criteria.
+
+Reference: Bessels.jl at https://github.com/heltonmc/Bessels.jl (`src/BesselFunctions/`, `src/AiryFunctions/`, `src/Math/`).


### PR DESCRIPTION
## Summary

Three commits on top of main:

- **`8b1ae4c` Add todo/ implementation roadmap** — `todo/README.md` plus six plans (`01`–`06`) for the functions still listed as "not yet implemented" in the README. Each plan cites Bessels.jl source files, names already-implemented helpers we can reuse, and lists step-by-step + tests + "done when".
- **`ad94655` Fix besselj_up_recurrence forward recurrence** — two-character fix: the loop used `nu_start` (constant) where it needed `nu` (running counter), and decremented `nu` instead of incrementing. Dormant today (only caller was the integer-ν Y path of `bessely_positive_args`, which wasn't exposed), but blocks `bessely(nu, x)` from working. Adds `test_besselj_up_recurrence` regression vs `bessel_yn` intrinsic.
- **`10115db` Wire up bessely, besselh, hankelh1, hankelh2, gamma_BK** — expose four new functions plus re-export `gamma_BK`, so `use bessels` is the single entry point. Wrappers call the existing private helpers (`bessely_positive_args`, `besselj_positive_args`).

## Caveats and follow-up

Writing closed-form half-integer reference tests for `bessely` surfaced **three pre-existing port bugs** in non-integer-ν branches: `bessely_power_series` argument-order swap, `bessely_chebyshev` table-index mismatch, and `hankel_debye` missing the complex part of `Uk_poly_Hankel` (the latter also divides by zero for ν=0, producing NaN).

To ship this PR clean rather than expanding scope:

- `besselh` bypasses `hankel_debye` and always composes `J + i·Y` — correct for integer ν at all x, slower than the planned fast path.
- New tests cover **integer ν only** (`test_bessely_nu_integer`, `test_hankelh1_consistency`, `test_hankelh2_conjugate`, plus two cputime benchmarks).
- Discovered bugs documented in [`todo/07-nonintegerNU-bugs.md`](https://github.com/perazz/fortran-bessels/blob/todo-implementation-plans/todo/07-nonintegerNU-bugs.md) with file/line refs and step-by-step fix plans — landing 07 restores correct non-integer ν, the half-integer Y identities test, the negative-ν Hankel reflection test, and the `hankel_debye` fast path.

## Test plan

- [x] All 27 existing + new tests pass on the manual gfortran build (`gfortran -O3 -march=native -ffast-math`).
- [x] No regression in existing benchmark ns/eval — `bessel_j0/j1/jn/y0/y1/k0/k1/i0/i1/gamma` timings unchanged within noise.
- [x] `[hankelh1] PACKAGE sum(z)` matches the `cmplx(besselj0, bessely0)` baseline (no NaN).
- [ ] `fpm test --profile release` on a machine with fpm installed (manual gfortran build was used here since fpm wasn't available).
- [ ] CI passes (if any).

## Files

- `src/bessels_constants.f90` — 2-line fix in `besselj_up_recurrence`
- `src/bessels.f90` — `use bessels_gamma`, four new public functions, expanded `public ::` list
- `test/bessels_test.f90` — 5 new test functions, registered in the driver; removed redundant `use bessels_gamma` from `test_gamma` / `test_gamma_cputime`
- `todo/` — 8 new markdown files (README + plans 01–07)